### PR TITLE
arm64ec dllimport allowing to get the addresses of the # prefixed arm functions

### DIFF
--- a/arm64ec_dllimport/README.md
+++ b/arm64ec_dllimport/README.md
@@ -27,3 +27,25 @@ DWORD64 LLW3 = FindDllExport(hProcess, ntdllBase, "#LdrLoadDll");
 # Supplementary notes
 
 The code is prepared to be used with https://github.com/rwfpl/rewolf-wow64ext allowing it to be hosted in a x86 32 bit process, a suitable analogon for 32bit arm needs still to be made.
+
+
+# Author
+David Xanatos (C) xanasoft.com
+
+# License
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ This file can be also used under the therms of the GLP and LGPL licenses.
+  Whatever floats your boat...
+

--- a/arm64ec_dllimport/README.md
+++ b/arm64ec_dllimport/README.md
@@ -1,0 +1,29 @@
+# What is this
+
+Its a hand made GetProcAddress which allows to get exported function addresses from x64 (or arm64ec) processes running on arm64 windows.
+When applied to a native arm64 process the result is same as from LdrGetProcedureAddress i.e. it returns the normal native export.
+Howe ever when called upon a x64 or arm64ec process it returns the result form the alternative export table namely the "EXP+#..." exports, i.e. the x64 stubs which invoke the native arm64 "#..." function.
+When the function name is prefixed with a '#' the provided FindDllExport extracts address the not directly exported native function and returns it.
+
+This library is suitable for finding entry points for code injection as well as to get function addresses to be used in shell code.
+
+The provided FindDllBase helper allows to locate the base address of a dll given a part of its path (or name only) in the address space of an other process.
+
+# Example
+
+//ntdllBase 0x00007ffa5a7d0000
+//0x00007ffa5a811050 {ntdll.dll!LdrLoadDll(void)}
+//0x00007ffa5a7d1890 {ntdll.dll!EXP+#LdrLoadDll}
+//0x00007ffa5a969920 {ntdll.dll!#LdrLoadDll}
+
+HMODULE hNtdll = GetModuleHandle(L"ntdll.dll");
+//DWORD64 LLW1 = GetProcAddress(hNtdll, "LdrLoadDll");
+DWORD64 LLW1 = FindDllExport(GetCurrentProcess(), (DWORD64)hNtdll, "LdrLoadDll");
+
+DWORD64 ntdllBase = FindDllBase(hProcess, L"\\system32\\ntdll.dll");
+DWORD64 LLW2 = FindDllExport(hProcess, ntdllBase, "LdrLoadDll");
+DWORD64 LLW3 = FindDllExport(hProcess, ntdllBase, "#LdrLoadDll");
+
+# Supplementary notes
+
+The code is prepared to be used with https://github.com/rwfpl/rewolf-wow64ext allowing it to be hosted in a x86 32 bit process, a suitable analogon for 32bit arm needs still to be made.

--- a/arm64ec_dllimport/dllimport.c
+++ b/arm64ec_dllimport/dllimport.c
@@ -1,10 +1,20 @@
 /*
  * Copyright 2022 David Xanatos, xanasoft.com
  *
- *   This program is distributed in the hope that it will be useful,
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *   GNU General Public License for more details.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This file can be also used under the therms of the GLP and LGPL licenses.
+ *  Whatever floats your boat...
  *
  */
  
@@ -17,6 +27,34 @@ typedef long NTSTATUS;
 #include <stdio.h>
 
 // ntimage.h
+
+
+typedef struct _IMAGE_CHPE_METADATA_X86 {
+	ULONG  Version;
+	ULONG  CHPECodeAddressRangeOffset;
+	ULONG  CHPECodeAddressRangeCount;
+	ULONG  WowA64ExceptionHandlerFunctionPointer;
+	ULONG  WowA64DispatchCallFunctionPointer;
+	ULONG  WowA64DispatchIndirectCallFunctionPointer;
+	ULONG  WowA64DispatchIndirectCallCfgFunctionPointer;
+	ULONG  WowA64DispatchRetFunctionPointer;
+	ULONG  WowA64DispatchRetLeafFunctionPointer;
+	ULONG  WowA64DispatchJumpFunctionPointer;
+	ULONG  CompilerIATPointer;         // Present if Version >= 2
+	ULONG  WowA64RdtscFunctionPointer; // Present if Version >= 3
+} IMAGE_CHPE_METADATA_X86, * PIMAGE_CHPE_METADATA_X86;
+
+typedef struct _IMAGE_CHPE_RANGE_ENTRY {
+	union {
+		ULONG StartOffset;
+		struct {
+			ULONG NativeCode : 1;
+			ULONG AddressBits : 31;
+		} DUMMYSTRUCTNAME;
+	} DUMMYUNIONNAME;
+
+	ULONG Length;
+} IMAGE_CHPE_RANGE_ENTRY, * PIMAGE_CHPE_RANGE_ENTRY;
 
 typedef struct _IMAGE_ARM64EC_METADATA {
 	ULONG  Version;
@@ -67,8 +105,7 @@ NTSYSCALLAPI NTSTATUS NTAPI NtReadVirtualMemory(
 	_In_opt_ PVOID BaseAddress,
 	_Out_writes_bytes_(BufferSize) PVOID Buffer,
 	_In_ SIZE_T BufferSize,
-	_Out_opt_ PSIZE_T NumberOfBytesRead
-);
+	_Out_opt_ PSIZE_T NumberOfBytesRead);
 
 NTSYSCALLAPI NTSTATUS NTAPI NtQueryVirtualMemory(
 	IN  HANDLE ProcessHandle,
@@ -78,17 +115,17 @@ NTSYSCALLAPI NTSTATUS NTAPI NtQueryVirtualMemory(
 	IN  SIZE_T MemoryInformationLength,
 	OUT PSIZE_T ReturnLength);
 
-#define NtReadVirtualMemory64(ProcessHandle, BaseAddress, Buffer, BufferSize, NumberOfBytesRead) \
-	NtReadVirtualMemory(ProcessHandle, (PVOID)(BaseAddress), Buffer, BufferSize, NumberOfBytesRead)
-
-#define NtQueryVirtualMemory64(ProcessHandle, BaseAddress, MemoryInformationClass, MemoryInformation, MemoryInformationLength, ReturnLength) \
-	NtQueryVirtualMemory(ProcessHandle, BaseAddress, MemoryInformationClass, MemoryInformation, MemoryInformationLength, ReturnLength)
+#define NtReadVirtualMemory64 NtReadVirtualMemory
+#define NtQueryVirtualMemory64 NtQueryVirtualMemory
 
 //#endif
 
-ULONG64 FindDllBase(_In_ HANDLE ProcessHandle, const WCHAR* dll)
+//void DbgPrintf(const char* format, ...);
+
+ULONG64 FindDllBase(HANDLE ProcessHandle, const WCHAR* dll)
 {
 	char buffer[512];
+	ULONG len = wcslen(dll);
 
 	for (PVOID baseAddress = NULL;;)
 	{
@@ -117,13 +154,14 @@ ULONG64 FindDllBase(_In_ HANDLE ProcessHandle, const WCHAR* dll)
 		)))
 		{
 			UNICODE_STRING* FullImageName = (UNICODE_STRING*)buffer;
-			if (FullImageName->Length > 19 * sizeof(WCHAR)) {
+			if (FullImageName->Length > len * sizeof(WCHAR)) {
 
 				WCHAR* path = FullImageName->Buffer
 					+ FullImageName->Length / sizeof(WCHAR)
-					- 19;
+					- len;
 				if (_wcsicmp(path, dll) == 0) {
 
+					//DbgPrintf("%S base address: 0x%08x%08x\n", dll, (ULONG)(basicInfo.AllocationBase >> 32), (ULONG)basicInfo.AllocationBase);
 					return (ULONG64)basicInfo.AllocationBase;
 				}
 			}
@@ -133,25 +171,78 @@ ULONG64 FindDllBase(_In_ HANDLE ProcessHandle, const WCHAR* dll)
 	return 0;
 }
 
-DWORD64 FindDllExport2(HANDLE hProcess, DWORD64 DllBase, IMAGE_DATA_DIRECTORY *dir0, const UCHAR* ProcName)
+
+
+typedef NTSYSCALLAPI NTSTATUS (__cdecl *P_ReadDll)(
+	_In_ HANDLE ProcessHandle,
+	_In_opt_ DWORD64 BaseAddress,
+	_Out_writes_bytes_(BufferSize) PVOID Buffer,
+	_In_ SIZE_T BufferSize,
+	_Out_opt_ PSIZE_T NumberOfBytesRead);
+
+
+IMAGE_SECTION_HEADER* FindImageSection(DWORD rva, PIMAGE_NT_HEADERS32 pNTHeader)
+{
+	PIMAGE_SECTION_HEADER section = IMAGE_FIRST_SECTION(pNTHeader);
+	for (ULONG i = 0; i < pNTHeader->FileHeader.NumberOfSections; i++, section++) {
+		DWORD size = section->Misc.VirtualSize;
+		if (size == 0)
+			size = section->SizeOfRawData;
+		if ((rva >= section->VirtualAddress) && (rva < (section->VirtualAddress + size)))
+			return section;
+	}
+	return NULL;
+}
+
+DWORD64 FindImagePosition(DWORD rva, void* pNTHeader, DWORD64 imageBase)
+{
+	if (imageBase != 0) // live image
+		return imageBase + rva;
+	// file on disk
+	IMAGE_SECTION_HEADER* pSectionHdr = FindImageSection(rva, pNTHeader);
+	if (!pSectionHdr)
+		return 0;
+	DWORD delta = pSectionHdr->VirtualAddress - pSectionHdr->PointerToRawData;
+	//return imageBase + rva - delta;
+	return rva - delta;
+}
+
+DWORD64 FindDllExport2(P_ReadDll ReadDll, HANDLE hProcess, DWORD64 DllBase, IMAGE_DATA_DIRECTORY *dir0, const char* ProcName, void* pNTHeader)
 {
 	NTSTATUS status;
 	BYTE* buffer;
 
+	//	dir0->VirtualAddress = ; // todo alternative loader dirctroy
+
 	DWORD64 proc = NULL;
 
-	buffer = HeapAlloc(GetProcessHeap(), 0, dir0->Size);
-	status = NtReadVirtualMemory64(hProcess, DllBase + dir0->VirtualAddress, buffer, dir0->Size, NULL);
+	DWORD64 dir0Address = FindImagePosition(dir0->VirtualAddress, pNTHeader, DllBase);
 
+	buffer = HeapAlloc(GetProcessHeap(), 0, dir0->Size);
+	//status = ReadDll(hProcess, DllBase + dir0->VirtualAddress, buffer, dir0->Size, NULL);
+	status = ReadDll(hProcess, dir0Address, buffer, dir0->Size, NULL);
+
+	//DbgPrintf("Export Address: 0x%08x\n", dir0->VirtualAddress);
+	//IMAGE_EXPORT_DIRECTORY* exports = (IMAGE_EXPORT_DIRECTORY*) ((BYTE*)DllBase + dir0->VirtualAddress);
 	IMAGE_EXPORT_DIRECTORY* exports = buffer;
+
+	//DbgPrintf("Export Names: 0x%08x\n", exports->AddressOfNames);
+	//ULONG* names = (ULONG*) ((BYTE*)DllBase + exports->AddressOfNames);
 	ULONG* names = (ULONG*)((DWORD64)buffer + exports->AddressOfNames - dir0->VirtualAddress);
+	
+	//DbgPrintf("Export Ordinals: 0x%08x\n", exports->AddressOfNameOrdinals);
+	//USHORT* ordinals = (USHORT*) ((BYTE*)DllBase + exports->AddressOfNameOrdinals);
 	USHORT* ordinals = (USHORT*)((DWORD64)buffer + exports->AddressOfNameOrdinals - dir0->VirtualAddress);
+
+	//DbgPrintf("Export Ordinals: 0x%08x\n", exports->AddressOfFunctions);
+	//ULONG* functions = (ULONG*) ((BYTE*)DllBase + exports->AddressOfFunctions);
 	ULONG* functions = (ULONG*)((DWORD64)buffer + exports->AddressOfFunctions - dir0->VirtualAddress);
 
 
 	for (ULONG i = 0; i < exports->NumberOfNames; ++i) {
-	
-		UCHAR* name = (UCHAR*)((DWORD64)exports + names[i] - dir0->VirtualAddress);
+
+		//BYTE* name = (BYTE*)DllBase + names[i];
+		char* name = (char*)((DWORD64)exports + names[i] - dir0->VirtualAddress);
 		
 		if(strcmp(name, ProcName) == 0)
 		{
@@ -163,21 +254,57 @@ DWORD64 FindDllExport2(HANDLE hProcess, DWORD64 DllBase, IMAGE_DATA_DIRECTORY *d
 		}
 	}
 
+	if (proc && proc >= dir0Address && proc < dir0Address + dir0->Size) {
+
+		//
+		// if the export points inside the export table, then it is a
+		// forwarder entry.  we don't handle these, because none of the
+		// exports we need is a forwarder entry.  if this changes, we
+		// might have to scan LDR tables to find the target dll
+		//
+
+		proc = NULL;
+	}
+
 	HeapFree(GetProcessHeap(), 0, buffer);
 
 	return proc;
 }
 
-DWORD64 ResolveWoWRedirection(HANDLE hProcess, DWORD64 DllBase, DWORD64 proc, DWORD64 CHPEMetadataPointer)
+DWORD64 ResolveWoWRedirection32(P_ReadDll ReadDll, HANDLE hProcess, DWORD64 DllBase, DWORD64 proc, DWORD64 CHPEMetadataPointer, void* pNTHeader)
+{
+	NTSTATUS status;
+
+	IMAGE_CHPE_METADATA_X86 MetaData;
+	status = ReadDll(hProcess, CHPEMetadataPointer, &MetaData, sizeof(MetaData), NULL);
+
+	/*ULONG size = MetaData.CHPECodeAddressRangeCount * sizeof(IMAGE_CHPE_RANGE_ENTRY);
+	BYTE* buffer = HeapAlloc(GetProcessHeap(), 0, size);
+	status = ReadDll(hProcess, FindImagePosition(MetaData.CHPECodeAddressRangeOffset, pNTHeader, DllBase), buffer, size, NULL);
+	IMAGE_CHPE_RANGE_ENTRY* RedirectionMetadata = buffer;
+
+	for (ULONG i = 0; i < MetaData.CHPECodeAddressRangeCount; i++) {
+		if ((proc - DllBase) == RedirectionMetadata[i].StartOffset) {
+			proc = DllBase + RedirectionMetadata[i].Destination;
+			break;
+		}
+	}
+
+	HeapFree(GetProcessHeap(), 0, buffer);*/
+
+	return proc;
+}
+
+DWORD64 ResolveWoWRedirection64(P_ReadDll ReadDll, HANDLE hProcess, DWORD64 DllBase, DWORD64 proc, DWORD64 CHPEMetadataPointer, void* pNTHeader)
 {
 	NTSTATUS status;
 
 	IMAGE_ARM64EC_METADATA MetaData;
-	status = NtReadVirtualMemory64(hProcess, CHPEMetadataPointer, &MetaData, sizeof(MetaData), NULL);
+	status = ReadDll(hProcess, CHPEMetadataPointer, &MetaData, sizeof(MetaData), NULL);
 
 	ULONG size = MetaData.RedirectionMetadataCount * sizeof(IMAGE_ARM64EC_REDIRECTION_ENTRY);
 	BYTE* buffer = HeapAlloc(GetProcessHeap(), 0, size);
-	status = NtReadVirtualMemory64(hProcess, DllBase + MetaData.RedirectionMetadata, buffer, size, NULL);
+	status = ReadDll(hProcess, FindImagePosition(MetaData.RedirectionMetadata, pNTHeader, DllBase), buffer, size, NULL);
 	IMAGE_ARM64EC_REDIRECTION_ENTRY* RedirectionMetadata = buffer;
 
 	for (ULONG i = 0; i < MetaData.RedirectionMetadataCount; i++) {
@@ -192,7 +319,7 @@ DWORD64 ResolveWoWRedirection(HANDLE hProcess, DWORD64 DllBase, DWORD64 proc, DW
 	return proc;
 }
 
-DWORD64 FindDllExport(HANDLE hProcess, DWORD64 DllBase, const UCHAR* ProcName)
+DWORD64 FindDllExport1(P_ReadDll ReadDll, HANDLE hProcess, DWORD64 DllBase, const char* ProcName)
 {
 	NTSTATUS status;
 	DWORD64 proc = NULL;
@@ -201,17 +328,22 @@ DWORD64 FindDllExport(HANDLE hProcess, DWORD64 DllBase, const UCHAR* ProcName)
 	IMAGE_NT_HEADERS* nt_hdrs;
 
 	BYTE Buffer1[0x10000];
-	status = NtReadVirtualMemory64(hProcess, DllBase, Buffer1, sizeof(Buffer1), NULL);
+	status = ReadDll(hProcess, DllBase, Buffer1, sizeof(Buffer1), NULL);
 
 	BOOLEAN resolve_wow = ProcName[0] == '#';
 	if (resolve_wow)
 		ProcName++;
 
+	//
+	// find the DllMain entrypoint for the dll
+	//
+
+	//dos_hdr = (void*)DllBase;
 	dos_hdr = Buffer1;
 
 	if (dos_hdr->e_magic != 'MZ' && dos_hdr->e_magic != 'ZM')
 		return NULL;
-	nt_hdrs = (IMAGE_NT_HEADERS*)((UCHAR*)dos_hdr + dos_hdr->e_lfanew);
+	nt_hdrs = (IMAGE_NT_HEADERS*)((BYTE*)dos_hdr + dos_hdr->e_lfanew);
 	if (nt_hdrs->Signature != IMAGE_NT_SIGNATURE)     // 'PE\0\0'
 		return NULL;
 
@@ -223,17 +355,20 @@ DWORD64 FindDllExport(HANDLE hProcess, DWORD64 DllBase, const UCHAR* ProcName)
 		if (opt_hdr_32->NumberOfRvaAndSizes) {
 
 			IMAGE_DATA_DIRECTORY* dir0 = &opt_hdr_32->DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT];
-			proc = FindDllExport2(hProcess, DllBase, dir0, ProcName);
+			proc = FindDllExport2(ReadDll, hProcess, DllBase, dir0, ProcName, nt_hdrs_32);
 
-			IMAGE_DATA_DIRECTORY* dir10 = &opt_hdr_32->DataDirectory[IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG];
-			if (resolve_wow && dir10->VirtualAddress && dir10->Size >= FIELD_OFFSET(IMAGE_LOAD_CONFIG_DIRECTORY32, CHPEMetadataPointer) + sizeof(ULONG)) {
+			//IMAGE_DATA_DIRECTORY* dir10 = &opt_hdr_32->DataDirectory[IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG];
+			//if (resolve_wow && dir10->VirtualAddress && dir10->Size >= FIELD_OFFSET(IMAGE_LOAD_CONFIG_DIRECTORY32, CHPEMetadataPointer) + sizeof(ULONG)) {
 
-				IMAGE_LOAD_CONFIG_DIRECTORY32 LoadConfig;
-				status = NtReadVirtualMemory64(hProcess, DllBase + dir10->VirtualAddress, &LoadConfig, min(sizeof(LoadConfig), dir10->Size), NULL);
+			//	IMAGE_LOAD_CONFIG_DIRECTORY32 LoadConfig;
+			//	status = ReadDll(hProcess, FindImagePosition(dir10->VirtualAddress, nt_hdrs_32, DllBase), &LoadConfig, min(sizeof(LoadConfig), dir10->Size), NULL);
 
-				if (LoadConfig.CHPEMetadataPointer)
-					proc = ResolveWoWRedirection(hProcess, DllBase, proc, LoadConfig.CHPEMetadataPointer);
-			}
+			//	if (LoadConfig.CHPEMetadataPointer) {
+			//		if (DllBase == 0) // file on disk
+			//			LoadConfig.CHPEMetadataPointer = FindImagePosition(LoadConfig.CHPEMetadataPointer - opt_hdr_32->ImageBase, nt_hdrs_32, DllBase);
+			//		proc = ResolveWoWRedirection32(ReadDll, hProcess, DllBase, proc, LoadConfig.CHPEMetadataPointer, nt_hdrs_32);
+			//	}
+			//}
 		}
 	}
 
@@ -245,19 +380,57 @@ DWORD64 FindDllExport(HANDLE hProcess, DWORD64 DllBase, const UCHAR* ProcName)
 		if (opt_hdr_64->NumberOfRvaAndSizes) {
 
 			IMAGE_DATA_DIRECTORY* dir0 = &opt_hdr_64->DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT];
-			proc = FindDllExport2(hProcess, DllBase, dir0, ProcName);
+			proc = FindDllExport2(ReadDll, hProcess, DllBase, dir0, ProcName, nt_hdrs_64);
 
 			IMAGE_DATA_DIRECTORY* dir10 = &opt_hdr_64->DataDirectory[IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG];
 			if (resolve_wow && dir10->VirtualAddress && dir10->Size >= FIELD_OFFSET(IMAGE_LOAD_CONFIG_DIRECTORY64, CHPEMetadataPointer) + sizeof(ULONGLONG)) {
 
 				IMAGE_LOAD_CONFIG_DIRECTORY64 LoadConfig;
-				status = NtReadVirtualMemory64(hProcess, DllBase + dir10->VirtualAddress, &LoadConfig, min(sizeof(LoadConfig), dir10->Size), NULL);
+				status = ReadDll(hProcess, FindImagePosition(dir10->VirtualAddress, nt_hdrs_64, DllBase), &LoadConfig, min(sizeof(LoadConfig), dir10->Size), NULL);
 
-				if (LoadConfig.CHPEMetadataPointer)
-					proc = ResolveWoWRedirection(hProcess, DllBase, proc, LoadConfig.CHPEMetadataPointer);
+				//LoadConfig.DynamicValueRelocTableSection
+
+				if (LoadConfig.CHPEMetadataPointer) {
+					if (DllBase == 0) // file on disk
+						LoadConfig.CHPEMetadataPointer = FindImagePosition(LoadConfig.CHPEMetadataPointer - opt_hdr_64->ImageBase, nt_hdrs_64, DllBase);
+					proc = ResolveWoWRedirection64(ReadDll, hProcess, DllBase, proc, LoadConfig.CHPEMetadataPointer, nt_hdrs_64);
+				}
 			}
 		}
 	}
 
+	return proc;
+}
+
+DWORD64 FindDllExport(HANDLE hProcess, DWORD64 DllBase, const char* ProcName)
+{
+	return FindDllExport1(NtReadVirtualMemory64, hProcess, DllBase, ProcName);
+}
+
+NTSTATUS __cdecl ReadDllFile(
+	_In_ HANDLE FileHandle,
+	_In_opt_ DWORD64 BaseAddress,
+	_Out_writes_bytes_(BufferSize) PVOID Buffer,
+	_In_ SIZE_T BufferSize,
+	_Out_opt_ PSIZE_T pNumberOfBytesRead)
+{
+	LARGE_INTEGER pos;
+	pos.QuadPart = BaseAddress;
+	SetFilePointerEx(FileHandle, pos, NULL, FILE_BEGIN);
+	DWORD NumberOfBytesRead;
+	BOOL ret = ReadFile(FileHandle, Buffer, BufferSize, &NumberOfBytesRead, NULL);
+	return STATUS_SUCCESS; // todo
+}
+
+DWORD64 FindDllExportFromFile(const WCHAR* dll, const char* ProcName)
+{
+	DWORD64 proc;
+	HANDLE hFile = CreateFileW(dll, GENERIC_READ, (FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE), NULL, OPEN_EXISTING, 0, NULL);
+	if (hFile == INVALID_HANDLE_VALUE)
+		return 0;
+
+	proc = FindDllExport1(ReadDllFile, hFile, 0, ProcName);
+
+	CloseHandle(hFile);
 	return proc;
 }

--- a/arm64ec_dllimport/dllimport.c
+++ b/arm64ec_dllimport/dllimport.c
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2022 David Xanatos, xanasoft.com
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ */
+ 
+#include <Ntstatus.h>
+#define WIN32_NO_STATUS
+typedef long NTSTATUS;
+
+#include <windows.h>
+#include <winternl.h>
+#include <stdio.h>
+
+// ntimage.h
+
+typedef struct _IMAGE_ARM64EC_METADATA {
+	ULONG  Version;
+	ULONG  CodeMap;
+	ULONG  CodeMapCount;
+	ULONG  CodeRangesToEntryPoints;
+	ULONG  RedirectionMetadata;
+	ULONG  tbd__os_arm64x_dispatch_call_no_redirect;
+	ULONG  tbd__os_arm64x_dispatch_ret;
+	ULONG  tbd__os_arm64x_dispatch_call;
+	ULONG  tbd__os_arm64x_dispatch_icall;
+	ULONG  tbd__os_arm64x_dispatch_icall_cfg;
+	ULONG  AlternateEntryPoint;
+	ULONG  AuxiliaryIAT;
+	ULONG  CodeRangesToEntryPointsCount;
+	ULONG  RedirectionMetadataCount;
+	ULONG  GetX64InformationFunctionPointer;
+	ULONG  SetX64InformationFunctionPointer;
+	ULONG  ExtraRFETable;
+	ULONG  ExtraRFETableSize;
+	ULONG  __os_arm64x_dispatch_fptr;
+	ULONG  AuxiliaryIATCopy;
+} IMAGE_ARM64EC_METADATA;
+
+typedef struct _IMAGE_ARM64EC_REDIRECTION_ENTRY {
+	ULONG Source;
+	ULONG Destination;
+} IMAGE_ARM64EC_REDIRECTION_ENTRY;
+
+// ntimage.h
+
+
+typedef enum _MEMORY_INFORMATION_CLASS {
+	MemoryBasicInformation,
+	MemoryWorkingSetInformation,
+	MemoryMappedFilenameInformation,
+	MemoryRegionInformation,
+	MemoryWorkingSetExInformation
+} MEMORY_INFORMATION_CLASS;
+
+//#include "../../wow64ext/misc_winnt.h"
+//#ifndef BUILD_ARCH_X64
+//#include "../../wow64ext/wow64ext.h"
+//#else
+
+NTSYSCALLAPI NTSTATUS NTAPI NtReadVirtualMemory(
+	_In_ HANDLE ProcessHandle,
+	_In_opt_ PVOID BaseAddress,
+	_Out_writes_bytes_(BufferSize) PVOID Buffer,
+	_In_ SIZE_T BufferSize,
+	_Out_opt_ PSIZE_T NumberOfBytesRead
+);
+
+NTSYSCALLAPI NTSTATUS NTAPI NtQueryVirtualMemory(
+	IN  HANDLE ProcessHandle,
+	IN  PVOID BaseAddress,
+	IN  MEMORY_INFORMATION_CLASS MemoryInformationClass,
+	OUT PVOID MemoryInformation,
+	IN  SIZE_T MemoryInformationLength,
+	OUT PSIZE_T ReturnLength);
+
+#define NtReadVirtualMemory64(ProcessHandle, BaseAddress, Buffer, BufferSize, NumberOfBytesRead) \
+	NtReadVirtualMemory(ProcessHandle, (PVOID)(BaseAddress), Buffer, BufferSize, NumberOfBytesRead)
+
+#define NtQueryVirtualMemory64(ProcessHandle, BaseAddress, MemoryInformationClass, MemoryInformation, MemoryInformationLength, ReturnLength) \
+	NtQueryVirtualMemory(ProcessHandle, BaseAddress, MemoryInformationClass, MemoryInformation, MemoryInformationLength, ReturnLength)
+
+//#endif
+
+ULONG64 FindDllBase(_In_ HANDLE ProcessHandle, const WCHAR* dll)
+{
+	char buffer[512];
+
+	for (PVOID baseAddress = NULL;;)
+	{
+		MEMORY_BASIC_INFORMATION64 basicInfo;
+		if (!NT_SUCCESS(NtQueryVirtualMemory64(
+			ProcessHandle,
+			baseAddress,
+			MemoryBasicInformation,
+			&basicInfo,
+			sizeof(MEMORY_BASIC_INFORMATION64),
+			NULL
+		)))
+		{
+			break;
+		}
+
+		baseAddress = (PVOID)((ULONG_PTR)(baseAddress)+(ULONG_PTR)(basicInfo.RegionSize));
+
+		if (NT_SUCCESS(NtQueryVirtualMemory64(
+			ProcessHandle,
+			basicInfo.AllocationBase,
+			MemoryMappedFilenameInformation,
+			buffer,
+			sizeof(buffer),
+			NULL
+		)))
+		{
+			UNICODE_STRING* FullImageName = (UNICODE_STRING*)buffer;
+			if (FullImageName->Length > 19 * sizeof(WCHAR)) {
+
+				WCHAR* path = FullImageName->Buffer
+					+ FullImageName->Length / sizeof(WCHAR)
+					- 19;
+				if (_wcsicmp(path, dll) == 0) {
+
+					return (ULONG64)basicInfo.AllocationBase;
+				}
+			}
+		}
+	}
+
+	return 0;
+}
+
+DWORD64 FindDllExport2(HANDLE hProcess, DWORD64 DllBase, IMAGE_DATA_DIRECTORY *dir0, const UCHAR* ProcName)
+{
+	NTSTATUS status;
+	BYTE* buffer;
+
+	DWORD64 proc = NULL;
+
+	buffer = HeapAlloc(GetProcessHeap(), 0, dir0->Size);
+	status = NtReadVirtualMemory64(hProcess, DllBase + dir0->VirtualAddress, buffer, dir0->Size, NULL);
+
+	IMAGE_EXPORT_DIRECTORY* exports = buffer;
+	ULONG* names = (ULONG*)((DWORD64)buffer + exports->AddressOfNames - dir0->VirtualAddress);
+	USHORT* ordinals = (USHORT*)((DWORD64)buffer + exports->AddressOfNameOrdinals - dir0->VirtualAddress);
+	ULONG* functions = (ULONG*)((DWORD64)buffer + exports->AddressOfFunctions - dir0->VirtualAddress);
+
+
+	for (ULONG i = 0; i < exports->NumberOfNames; ++i) {
+	
+		UCHAR* name = (UCHAR*)((DWORD64)exports + names[i] - dir0->VirtualAddress);
+		
+		if(strcmp(name, ProcName) == 0)
+		{
+			if (ordinals[i] < exports->NumberOfFunctions) {
+
+				proc = DllBase + functions[ordinals[i]];
+				break;
+			}
+		}
+	}
+
+	HeapFree(GetProcessHeap(), 0, buffer);
+
+	return proc;
+}
+
+DWORD64 ResolveWoWRedirection(HANDLE hProcess, DWORD64 DllBase, DWORD64 proc, DWORD64 CHPEMetadataPointer)
+{
+	NTSTATUS status;
+
+	IMAGE_ARM64EC_METADATA MetaData;
+	status = NtReadVirtualMemory64(hProcess, CHPEMetadataPointer, &MetaData, sizeof(MetaData), NULL);
+
+	ULONG size = MetaData.RedirectionMetadataCount * sizeof(IMAGE_ARM64EC_REDIRECTION_ENTRY);
+	BYTE* buffer = HeapAlloc(GetProcessHeap(), 0, size);
+	status = NtReadVirtualMemory64(hProcess, DllBase + MetaData.RedirectionMetadata, buffer, size, NULL);
+	IMAGE_ARM64EC_REDIRECTION_ENTRY* RedirectionMetadata = buffer;
+
+	for (ULONG i = 0; i < MetaData.RedirectionMetadataCount; i++) {
+		if ((proc - DllBase) == RedirectionMetadata[i].Source) {
+			proc = DllBase + RedirectionMetadata[i].Destination;
+			break;
+		}
+	}
+
+	HeapFree(GetProcessHeap(), 0, buffer);
+
+	return proc;
+}
+
+DWORD64 FindDllExport(HANDLE hProcess, DWORD64 DllBase, const UCHAR* ProcName)
+{
+	NTSTATUS status;
+	DWORD64 proc = NULL;
+
+	IMAGE_DOS_HEADER* dos_hdr;
+	IMAGE_NT_HEADERS* nt_hdrs;
+
+	BYTE Buffer1[0x10000];
+	status = NtReadVirtualMemory64(hProcess, DllBase, Buffer1, sizeof(Buffer1), NULL);
+
+	BOOLEAN resolve_wow = ProcName[0] == '#';
+	if (resolve_wow)
+		ProcName++;
+
+	dos_hdr = Buffer1;
+
+	if (dos_hdr->e_magic != 'MZ' && dos_hdr->e_magic != 'ZM')
+		return NULL;
+	nt_hdrs = (IMAGE_NT_HEADERS*)((UCHAR*)dos_hdr + dos_hdr->e_lfanew);
+	if (nt_hdrs->Signature != IMAGE_NT_SIGNATURE)     // 'PE\0\0'
+		return NULL;
+
+	if (nt_hdrs->OptionalHeader.Magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC) {
+
+		IMAGE_NT_HEADERS32* nt_hdrs_32 = (IMAGE_NT_HEADERS32*)nt_hdrs;
+		IMAGE_OPTIONAL_HEADER32* opt_hdr_32 = &nt_hdrs_32->OptionalHeader;
+
+		if (opt_hdr_32->NumberOfRvaAndSizes) {
+
+			IMAGE_DATA_DIRECTORY* dir0 = &opt_hdr_32->DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT];
+			proc = FindDllExport2(hProcess, DllBase, dir0, ProcName);
+
+			IMAGE_DATA_DIRECTORY* dir10 = &opt_hdr_32->DataDirectory[IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG];
+			if (resolve_wow && dir10->VirtualAddress && dir10->Size >= FIELD_OFFSET(IMAGE_LOAD_CONFIG_DIRECTORY32, CHPEMetadataPointer) + sizeof(ULONG)) {
+
+				IMAGE_LOAD_CONFIG_DIRECTORY32 LoadConfig;
+				status = NtReadVirtualMemory64(hProcess, DllBase + dir10->VirtualAddress, &LoadConfig, min(sizeof(LoadConfig), dir10->Size), NULL);
+
+				if (LoadConfig.CHPEMetadataPointer)
+					proc = ResolveWoWRedirection(hProcess, DllBase, proc, LoadConfig.CHPEMetadataPointer);
+			}
+		}
+	}
+
+	else if (nt_hdrs->OptionalHeader.Magic == IMAGE_NT_OPTIONAL_HDR64_MAGIC) {
+
+		IMAGE_NT_HEADERS64* nt_hdrs_64 = (IMAGE_NT_HEADERS64*)nt_hdrs;
+		IMAGE_OPTIONAL_HEADER64* opt_hdr_64 = &nt_hdrs_64->OptionalHeader;
+
+		if (opt_hdr_64->NumberOfRvaAndSizes) {
+
+			IMAGE_DATA_DIRECTORY* dir0 = &opt_hdr_64->DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT];
+			proc = FindDllExport2(hProcess, DllBase, dir0, ProcName);
+
+			IMAGE_DATA_DIRECTORY* dir10 = &opt_hdr_64->DataDirectory[IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG];
+			if (resolve_wow && dir10->VirtualAddress && dir10->Size >= FIELD_OFFSET(IMAGE_LOAD_CONFIG_DIRECTORY64, CHPEMetadataPointer) + sizeof(ULONGLONG)) {
+
+				IMAGE_LOAD_CONFIG_DIRECTORY64 LoadConfig;
+				status = NtReadVirtualMemory64(hProcess, DllBase + dir10->VirtualAddress, &LoadConfig, min(sizeof(LoadConfig), dir10->Size), NULL);
+
+				if (LoadConfig.CHPEMetadataPointer)
+					proc = ResolveWoWRedirection(hProcess, DllBase, proc, LoadConfig.CHPEMetadataPointer);
+			}
+		}
+	}
+
+	return proc;
+}

--- a/arm64ec_dllimport/dllimport.c
+++ b/arm64ec_dllimport/dllimport.c
@@ -250,8 +250,9 @@ DWORD64 FindDllExport2(P_ReadDll ReadDll, HANDLE hProcess, DWORD64 DllBase, IMAG
 
 				proc = DllBase + functions[ordinals[i]];
 
-				if (((PIMAGE_NT_HEADERS32)pNTHeader)->FileHeader.Machine == IMAGE_FILE_MACHINE_ARMNT)
-					proc -= 1; // WTF why is that needed?
+        // Note: if this is an arm32 image the real address has a 0x01 appended to indicate it uses the thumb instruction set
+				//if (((PIMAGE_NT_HEADERS32)pNTHeader)->FileHeader.Machine == IMAGE_FILE_MACHINE_ARMNT)
+				//	proc &= ~1;
 
 				break;
 			}

--- a/arm64ec_dllimport/dllimport.c
+++ b/arm64ec_dllimport/dllimport.c
@@ -249,6 +249,10 @@ DWORD64 FindDllExport2(P_ReadDll ReadDll, HANDLE hProcess, DWORD64 DllBase, IMAG
 			if (ordinals[i] < exports->NumberOfFunctions) {
 
 				proc = DllBase + functions[ordinals[i]];
+
+				if (((PIMAGE_NT_HEADERS32)pNTHeader)->FileHeader.Machine == IMAGE_FILE_MACHINE_ARMNT)
+					proc -= 1; // WTF why is that needed?
+
 				break;
 			}
 		}

--- a/arm64ec_dllimport/example.cpp
+++ b/arm64ec_dllimport/example.cpp
@@ -1,0 +1,97 @@
+#include <stdio.h>
+#include <windows.h>
+#include <winternl.h>
+
+extern "C" {
+
+NTSYSCALLAPI NTSTATUS NTAPI NtAllocateVirtualMemory(
+	_In_ HANDLE ProcessHandle,
+	_Inout_ PVOID* BaseAddress,
+	_In_ ULONG_PTR ZeroBits,
+	_Inout_ PSIZE_T RegionSize,
+	_In_ ULONG AllocationType,
+	_In_ ULONG Protect
+);
+
+NTSYSCALLAPI NTSTATUS NTAPI NtReadVirtualMemory(
+	_In_ HANDLE ProcessHandle,
+	_In_opt_ PVOID BaseAddress,
+	_Out_writes_bytes_(BufferSize) PVOID Buffer,
+	_In_ SIZE_T BufferSize,
+	_Out_opt_ PSIZE_T NumberOfBytesRead
+);
+
+
+NTSYSCALLAPI NTSTATUS NTAPI NtWriteVirtualMemory(
+	_In_ HANDLE ProcessHandle,
+	_In_opt_ PVOID BaseAddress,
+	_In_reads_bytes_(BufferSize) PVOID Buffer,
+	_In_ SIZE_T BufferSize,
+	_Out_opt_ PSIZE_T NumberOfBytesWritten
+);
+
+NTSYSCALLAPI NTSTATUS NTAPI NtProtectVirtualMemory(
+	_In_ HANDLE ProcessHandle,
+	_Inout_ PVOID* BaseAddress,
+	_Inout_ PSIZE_T RegionSize,
+	_In_ ULONG NewProtect,
+	_Out_ PULONG OldProtect
+);
+
+NTSYSCALLAPI NTSTATUS NTAPI NtFlushInstructionCache(
+	_In_ HANDLE ProcessHandle,
+	_In_opt_ PVOID BaseAddress,
+	_In_ SIZE_T Length
+);
+
+	ULONG64 FindDllBase(HANDLE ProcessHandle, const WCHAR* dll);
+	DWORD64 FindDllExport(HANDLE hProcess, DWORD64 DllBase, const char* ProcName);
+}
+
+int main()
+{
+	wchar_t prog[MAX_PATH] = L"C:\\windows\\system32\\cmd.exe";
+
+	STARTUPINFOW si = { 0 };
+	PROCESS_INFORMATION pi = { 0 };
+	si.cb = sizeof(STARTUPINFO);
+	if (!CreateProcessW(NULL, prog, NULL, NULL, FALSE, CREATE_SUSPENDED, NULL, NULL, &si, &pi)) {
+		fprintf(stderr, "CreateProcess(\"%S\") failed; error code = 0x%08X\n", prog, GetLastError());
+		return 1;
+	}
+
+	DWORD64 ntdllBase = FindDllBase(pi.hProcess, L"ntdll.dll");
+	DWORD64 pTargetFunc = FindDllExport(pi.hProcess, ntdllBase, "#LdrInitializeThunk");
+
+	UCHAR code[24];
+
+	union
+	{
+		PBYTE pB;
+		PWORD  pW;
+		PDWORD pL;
+		PDWORD64 pQ;
+	} ip;
+	ip.pB = code;
+
+	*ip.pL++ = 0xD43E0000;		// brk #0xF000 // ARM
+	//*ip.pB++ = 0xCC;			// int3 // x86/x64
+
+	void* RegionBase = (void*)pTargetFunc;
+	SIZE_T RegionSize = sizeof(code);
+	ULONG OldProtect;
+	NtProtectVirtualMemory(pi.hProcess, &RegionBase, &RegionSize, PAGE_EXECUTE_READWRITE, &OldProtect);
+
+	NtWriteVirtualMemory(pi.hProcess, (void*)pTargetFunc, code, ip.pB - code, NULL);
+
+	NtFlushInstructionCache(pi.hProcess, (void*)pTargetFunc, ip.pB - code);
+
+	if (ResumeThread(pi.hThread) == -1) {
+		fprintf(stderr, "ResumeThread failed; error code = 0x%08X\n", GetLastError());
+		return 1;
+	}
+
+	CloseHandle(pi.hThread);
+	CloseHandle(pi.hProcess);
+	return 0;
+}

--- a/arm64ec_dllimport/example.cpp
+++ b/arm64ec_dllimport/example.cpp
@@ -1,3 +1,23 @@
+/*
+ * Copyright 2022 David Xanatos, xanasoft.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This file can be also used under the therms of the GLP and LGPL licenses.
+ *  Whatever floats your boat...
+ *
+ */
+ 
 #include <stdio.h>
 #include <windows.h>
 #include <winternl.h>

--- a/arm64ec_dllimport/example.sln
+++ b/arm64ec_dllimport/example.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.32126.315
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "example", "example.vcxproj", "{798E4D8F-618E-41C4-B06D-527209A65AC8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{798E4D8F-618E-41C4-B06D-527209A65AC8}.Debug|x64.ActiveCfg = Debug|x64
+		{798E4D8F-618E-41C4-B06D-527209A65AC8}.Debug|x64.Build.0 = Debug|x64
+		{798E4D8F-618E-41C4-B06D-527209A65AC8}.Debug|x86.ActiveCfg = Debug|Win32
+		{798E4D8F-618E-41C4-B06D-527209A65AC8}.Debug|x86.Build.0 = Debug|Win32
+		{798E4D8F-618E-41C4-B06D-527209A65AC8}.Release|x64.ActiveCfg = Release|x64
+		{798E4D8F-618E-41C4-B06D-527209A65AC8}.Release|x64.Build.0 = Release|x64
+		{798E4D8F-618E-41C4-B06D-527209A65AC8}.Release|x86.ActiveCfg = Release|Win32
+		{798E4D8F-618E-41C4-B06D-527209A65AC8}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {FDC0F1EE-BA5E-4861-A506-68D576FB456D}
+	EndGlobalSection
+EndGlobal

--- a/arm64ec_dllimport/example.vcxproj
+++ b/arm64ec_dllimport/example.vcxproj
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{798e4d8f-618e-41c4-b06d-527209a65ac8}</ProjectGuid>
+    <RootNamespace>example</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>ntdll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="dllimport.c" />
+    <ClCompile Include="example.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/arm64ec_dllimport/example.vcxproj.filters
+++ b/arm64ec_dllimport/example.vcxproj.filters
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="example.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="dllimport.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/docs_src/src/assets/ksarm64_h_CHPEV2.PNG:Zone.Identifier
+++ b/docs_src/src/assets/ksarm64_h_CHPEV2.PNG:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://doc-0k-ac-docs.googleusercontent.com/docs/securesc/o46iidl93aead61n9lkg67vb86hgda6k/1ej93tunguqfj38uc0r5138ro60hg6dh/1626065025000/04013550161108499888/04013550161108499888/1oANuRUKR3i11rBWsw2jXPlJPjtdfFXl_?e=download&authuser=1&nonce=9r6l8uaijl7pa&user=04013550161108499888&hash=01snnj5s557m5t7k4ibn03ng1cg1md2r


### PR DESCRIPTION
Its a hand made GetProcAddress which allows to get exported function addresses from x64 (or arm64ec) processes running on arm64 windows.
When applied to a native arm64 process the result is same as from LdrGetProcedureAddress i.e. it returns the normal native export.
Howe ever when called upon a x64 or arm64ec process it returns the result form the alternative export table namely the "EXP+#..." exports, i.e. the x64 stubs which invoke the native arm64 "#..." function.
When the function name is prefixed with a '#' the provided FindDllExport extracts address the not directly exported native function and returns it.

This library is suitable for finding entry points for code injection as well as to get function addresses to be used in shell code.

The provided FindDllBase helper allows to locate the base address of a dll given a part of its path (or name only) in the address space of an other process.
